### PR TITLE
Feat/history analyzer

### DIFF
--- a/backend/modules/history/history_analyzer.py
+++ b/backend/modules/history/history_analyzer.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+
+from browser_history import get_history
+from browser_history import browsers
+
+from urllib.parse import urlparse
+
+# Gathers the histories from all available browsers
+#
+# The histories in [(datetime, url)] format can be accessed through outputs.histories
+# Some useful methods of the returned object are to_json() and to_csv(), both returning strings
+# 
+def fetch_all():
+    return get_history()
+
+# Gathers information from specific browsers
+#
+# The browsers to be analyzed are specified in the first argument, which is an array of strings
+# 
+def fetch_specific(args):
+    dict_browsers = {
+            'Brave': browsers.Brave,
+            'Chrome': browsers.Chrome,
+            'Chromium': browsers.Chromium,
+            'Edge': browsers.Edge,
+            'Firefox': browsers.Firefox,
+            'Opera': browsers.Opera,
+            'OperaGX': browsers.OperaGX,
+            'Safari': browsers.Safari
+    }
+
+    output = {}
+
+    for browser_name in args:
+        if browser_name in dict_browsers:
+            try:
+                brows_init = dict_browsers[browser_name]()
+            
+                output[browser_name] = brows_init.fetch_history()
+            except AssertionError:
+                print('INFO: browser {} not supported'.format(browser_name))
+
+    return output
+
+if __name__ == '__main__':
+    print(fetch_all().histories)

--- a/backend/modules/history/history_analyzer.py
+++ b/backend/modules/history/history_analyzer.py
@@ -4,20 +4,26 @@
 from browser_history import get_history
 from browser_history import browsers
 
-from urllib.parse import urlparse
+import summarize
 
 # Gathers the histories from all available browsers
 #
+# The object returned is of type <browser_history.generic.Outputs>
 # The histories in [(datetime, url)] format can be accessed through outputs.histories
 # Some useful methods of the returned object are to_json() and to_csv(), both returning strings
-# 
+#
+# One thing to note is that the data obtained from this method deosn't distinguish between
+# browsers, meaning you can't find out which entry belongs to which browser
+#
 def fetch_all():
     return get_history()
 
 # Gathers information from specific browsers
 #
 # The browsers to be analyzed are specified in the first argument, which is an array of strings
-# 
+# The output format is { browser_name: <browser_history.generic.Outputs> }; you can check
+# pesos/browser_history's documentation for details of the Outputs object
+#
 def fetch_specific(args):
     dict_browsers = {
             'Brave': browsers.Brave,
@@ -44,4 +50,7 @@ def fetch_specific(args):
     return output
 
 if __name__ == '__main__':
-    print(fetch_all().histories)
+    data = fetch_specific(['Firefox'])['Firefox']
+    print(data)
+    print(summarize.summarize_by_domain(data.histories))
+    print(summarize.summarize_by_path(data.histories))

--- a/backend/modules/history/summarize.py
+++ b/backend/modules/history/summarize.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+
+from urllib.parse import urlparse
+
+### Generic tmeplate for various possible operations with histories
+#
+# The idea is to return an output as { key: amount }
+# The key is provided by the get_key_lambda argument,
+# which is then used to classify the whole history
+#
+# In order to use custom geT_key lambdas keep in mind that
+# they must take a single argument, which is a history entry
+# with format (datetime, url)
+
+def summarize_generic(histories, get_key_lambda):
+
+    summarized = {}
+
+    for entry in histories:
+        if get_key_lambda(entry) in summarized:
+            summarized[get_key_lambda(entry)] += 1
+        else:
+            summarized[get_key_lambda(entry)] = 1
+
+    return summarized
+
+### Counts how many entries there are with equal domains
+#
+# Uses the urllib library for parsing the urls
+
+def summarize_by_domain(histories):
+    get_key = lambda entry: urlparse(entry[1]).netloc
+
+    return summarize_generic(histories, get_key)
+
+### Counts how many entries there are with equal paths (domain+path, without queries or fragments)
+# 
+# Uses the urllib library for parsing the urls
+
+def summarize_by_path(histories):
+    get_key = lambda entry: urlparse(entry[1]).netloc + urlparse(entry[1]).path
+
+    return summarize_generic(histories, get_key)
+


### PR DESCRIPTION
# History retrieval
History retrieval is pretty straight-forward, as shown in [browser-history](https://github.com/pesos/browser-history)'s documentation. Two functions were written, one for the retrieval of histories from all browsers and another one to look for specific browsers. One thing to note is that the first function described does not distinguish between browsers; meaning that with the data obtained one cannot tell which entries are from which browser. We could consider adding a third function that looks for all histories, but can distinguish between entries from different browsers.
# Summarization
The key idea to the `summarize.py` file is to provide a generic function, `summarize_generic`, that allows us to reinterpret the data obtained from different angles. Thus, we can analyze repetitions of domain and path, like the functions provided in the same file. We could also analyze the number of pages visited per day, per hour or per minute, and draw conclusions about when does the most traffic take place. The only drawback of this approach is that, however versatile, it makes use of a lambda function. We could try to find a different approach to this generic or even remove it, limiting ourselves to writing specific functions for different summarizatios, for the sake of code simplicity.

I hope this code is up to this project's expectations,
AgusNeira